### PR TITLE
Add extern "C"

### DIFF
--- a/include/uv_link_t.h
+++ b/include/uv_link_t.h
@@ -3,6 +3,9 @@
 
 #include "uv.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 typedef struct uv_link_s uv_link_t;
 typedef struct uv_link_methods_s uv_link_methods_t;
 typedef struct uv_link_source_s uv_link_source_t;
@@ -187,4 +190,7 @@ void uv_link_default_read_cb_override(uv_link_t* link,
                                       ssize_t nread,
                                       const uv_buf_t* buf);
 
+#ifdef __cplusplus
+}
+#endif
 #endif  /* INCLUDE_UV_LINK_H_ */


### PR DESCRIPTION
Similary in libuv, I wrapped the header with `extern "C"` macro to let the library be used C++ ecosystem
